### PR TITLE
COC-135 TabMenu 컴포넌트 구현

### DIFF
--- a/src/components/_common/molecules/TabMenu/index.tsx
+++ b/src/components/_common/molecules/TabMenu/index.tsx
@@ -1,27 +1,19 @@
-import { useState } from 'react';
 import S from './style';
 
 type TabMenuProps<T extends readonly string[]> = {
   tabs: T;
-  onTabChange?: (index: number) => void;
-  defaultMenu?: number;
+  selectedTab: string;
+  onTabChange?: (menu: T[number]) => void;
 };
 
-export default function TabMenu<T extends readonly string[]>({ tabs, onTabChange, defaultMenu = 0 }: TabMenuProps<T>) {
-  const [menuIndex, setMenuIndex] = useState(defaultMenu);
-
-  const handleClick = (index: number) => {
-    setMenuIndex(index);
-    onTabChange?.(index);
-  };
-
+export default function TabMenu<T extends readonly string[]>({ tabs, selectedTab, onTabChange }: TabMenuProps<T>) {
   return (
     <S.TabMenuContainer>
-      {tabs.map((menu, index) => (
+      {tabs.map((menu) => (
         <S.TabElement
           key={menu}
-          onClick={() => handleClick(index)}
-          $isSelected={menuIndex === index}
+          onClick={() => onTabChange?.(menu)}
+          $isSelected={selectedTab === menu}
         >
           {menu}
         </S.TabElement>

--- a/src/components/_common/molecules/TabMenu/index.tsx
+++ b/src/components/_common/molecules/TabMenu/index.tsx
@@ -13,7 +13,7 @@ export default function TabMenu<T extends readonly string[]>({ tabs, selectedTab
         <S.TabElement
           key={menu}
           onClick={() => onTabChange?.(menu)}
-          $isSelected={selectedTab === menu}
+          isSelected={selectedTab === menu}
         >
           {menu}
         </S.TabElement>

--- a/src/components/_common/molecules/TabMenu/index.tsx
+++ b/src/components/_common/molecules/TabMenu/index.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import S from './style';
+
+type TabMenuProps<T extends readonly string[]> = {
+  tab: T;
+  onTabChange?: (index: number) => void;
+  defaultTab?: number;
+};
+
+export default function TabMenu<T extends readonly string[]>({ tab, onTabChange, defaultTab = 0 }: TabMenuProps<T>) {
+  const [tabIndex, setTabIndex] = useState(defaultTab);
+
+  const handleClick = (index: number) => {
+    setTabIndex(index);
+    onTabChange?.(index);
+  };
+
+  return (
+    <S.TabMenuContainer>
+      {tab.map((element, index) => (
+        <S.TabElement
+          key={element}
+          onClick={() => handleClick(index)}
+          $isSelected={tabIndex === index}
+        >
+          {element}
+        </S.TabElement>
+      ))}
+    </S.TabMenuContainer>
+  );
+}

--- a/src/components/_common/molecules/TabMenu/index.tsx
+++ b/src/components/_common/molecules/TabMenu/index.tsx
@@ -2,28 +2,28 @@ import { useState } from 'react';
 import S from './style';
 
 type TabMenuProps<T extends readonly string[]> = {
-  tab: T;
+  tabs: T;
   onTabChange?: (index: number) => void;
-  defaultTab?: number;
+  defaultMenu?: number;
 };
 
-export default function TabMenu<T extends readonly string[]>({ tab, onTabChange, defaultTab = 0 }: TabMenuProps<T>) {
-  const [tabIndex, setTabIndex] = useState(defaultTab);
+export default function TabMenu<T extends readonly string[]>({ tabs, onTabChange, defaultMenu = 0 }: TabMenuProps<T>) {
+  const [menuIndex, setMenuIndex] = useState(defaultMenu);
 
   const handleClick = (index: number) => {
-    setTabIndex(index);
+    setMenuIndex(index);
     onTabChange?.(index);
   };
 
   return (
     <S.TabMenuContainer>
-      {tab.map((element, index) => (
+      {tabs.map((menu, index) => (
         <S.TabElement
-          key={element}
+          key={menu}
           onClick={() => handleClick(index)}
-          $isSelected={tabIndex === index}
+          $isSelected={menuIndex === index}
         >
-          {element}
+          {menu}
         </S.TabElement>
       ))}
     </S.TabMenuContainer>

--- a/src/components/_common/molecules/TabMenu/style.ts
+++ b/src/components/_common/molecules/TabMenu/style.ts
@@ -8,12 +8,12 @@ const TabMenuContainer = styled.div`
   border-bottom: 3px solid ${({ theme }) => theme.color.gray[400]};
 `;
 
-const TabElement = styled.div<{ $isSelected: boolean }>`
+const TabElement = styled.div<{ isSelected: boolean }>`
   position: relative;
   padding: 1rem 1.5rem;
 
   ${({ theme }) => theme.font.heading[300]};
-  color: ${({ theme, $isSelected }) => ($isSelected ? theme.color.gray[950] : theme.color.gray[400])};
+  color: ${({ theme, isSelected }) => (isSelected ? theme.color.gray[950] : theme.color.gray[400])};
 
   cursor: pointer;
 
@@ -26,7 +26,7 @@ const TabElement = styled.div<{ $isSelected: boolean }>`
     width: 100%;
     height: 0.3rem;
 
-    background-color: ${({ theme, $isSelected }) => ($isSelected ? theme.color.primary[300] : 'transparent')};
+    background-color: ${({ theme, isSelected }) => (isSelected ? theme.color.primary[300] : 'transparent')};
     z-index: 1;
   }
 `;

--- a/src/components/_common/molecules/TabMenu/style.ts
+++ b/src/components/_common/molecules/TabMenu/style.ts
@@ -21,10 +21,10 @@ const TabElement = styled.div<{ $isSelected: boolean }>`
     content: '';
 
     position: absolute;
-    bottom: -0.4rem;
+    bottom: -0.3rem;
     left: 0;
     width: 100%;
-    height: 0.4rem;
+    height: 0.3rem;
 
     background-color: ${({ theme, $isSelected }) => ($isSelected ? theme.color.primary[300] : 'transparent')};
     z-index: 1;

--- a/src/components/_common/molecules/TabMenu/style.ts
+++ b/src/components/_common/molecules/TabMenu/style.ts
@@ -4,23 +4,28 @@ const TabMenuContainer = styled.div`
   display: flex;
   position: relative;
   margin: 0 1rem 0 1rem;
+
   border-bottom: 3px solid ${({ theme }) => theme.color.gray[400]};
 `;
 
 const TabElement = styled.div<{ $isSelected: boolean }>`
-  cursor: pointer;
-  padding: 1rem 1.5rem 1rem 1.5rem;
   position: relative;
-  font-size: ${({ theme }) => theme.font.heading[300]};
+  padding: 1rem 1.5rem 1rem 1.5rem;
+
+  ${({ theme }) => theme.font.heading[300]};
   color: ${({ theme, $isSelected }) => ($isSelected ? theme.color.gray[950] : theme.color.gray[400])};
+
+  cursor: pointer;
 
   &::after {
     content: '';
+
     position: absolute;
     bottom: -0.4rem;
     left: 0;
     width: 100%;
     height: 0.4rem;
+
     background-color: ${({ theme, $isSelected }) => ($isSelected ? theme.color.primary[300] : 'transparent')};
     z-index: 1;
   }

--- a/src/components/_common/molecules/TabMenu/style.ts
+++ b/src/components/_common/molecules/TabMenu/style.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+const TabMenuContainer = styled.div`
+  display: flex;
+  position: relative;
+  margin: 0 1rem 0 1rem;
+  border-bottom: 3px solid ${({ theme }) => theme.color.gray[400]};
+`;
+
+const TabElement = styled.div<{ $isSelected: boolean }>`
+  cursor: pointer;
+  padding: 1rem 1.5rem 1rem 1.5rem;
+  position: relative;
+  font-size: ${({ theme }) => theme.font.heading[300]};
+  color: ${({ theme, $isSelected }) => ($isSelected ? theme.color.gray[950] : theme.color.gray[400])};
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -0.4rem;
+    left: 0;
+    width: 100%;
+    height: 0.4rem;
+    background-color: ${({ theme, $isSelected }) => ($isSelected ? theme.color.primary[300] : 'transparent')};
+    z-index: 1;
+  }
+`;
+
+const S = {
+  TabMenuContainer,
+  TabElement,
+};
+
+export default S;

--- a/src/components/_common/molecules/TabMenu/style.ts
+++ b/src/components/_common/molecules/TabMenu/style.ts
@@ -3,14 +3,14 @@ import styled from '@emotion/styled';
 const TabMenuContainer = styled.div`
   display: flex;
   position: relative;
-  margin: 0 1rem 0 1rem;
+  margin: 0 1rem;
 
   border-bottom: 3px solid ${({ theme }) => theme.color.gray[400]};
 `;
 
 const TabElement = styled.div<{ $isSelected: boolean }>`
   position: relative;
-  padding: 1rem 1.5rem 1rem 1.5rem;
+  padding: 1rem 1.5rem;
 
   ${({ theme }) => theme.font.heading[300]};
   color: ${({ theme, $isSelected }) => ($isSelected ? theme.color.gray[950] : theme.color.gray[400])};

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -7,6 +7,7 @@ export const LANGUAGE_IMAGES: Record<string, string> = {
 
 export const PROGRAMMING_LANGUAGES = ['Python', 'JavaScript', 'Java', 'C'] as const;
 export const STEPS = ['대기', '진행', '피드백', '종료'] as const;
+export const STUDY_LIST = ['코딩 스페이스', '멤버 보기', '스터디 정보'] as const;
 
 export type ProgrammingLanguage = (typeof PROGRAMMING_LANGUAGES)[number];
 export type Steps = (typeof STEPS)[number];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #29 

<br/>

## 🔎 작업 내용

- 스터디 리스트 constant 작성
- 탭 메뉴 구현 + 디자인
- tabs 프롭스에 배열을 넣게 되면 배열의 목록으로 탭 메뉴가 렌더링 될 수 있도록 함
- onTabChange : 다른 탭을 클릭했을 경우 설정할 이벤트 
- 현재는 클릭시 focus 효과만 넣었음, 추가 이벤트 설정 시 onTabChange 이용 
  ex) 클릭 시 메뉴에 따른 화면 변환

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
