### PR TITLE
COC-140 Axios 인터셉터 및 에러 핸들링, 토큰 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.env
 dist
 dist-ssr
 *.local

--- a/src/api/HTTPError.ts
+++ b/src/api/HTTPError.ts
@@ -1,0 +1,15 @@
+export class HTTPError extends Error {
+  statusCode: number;
+
+  code?: number;
+
+  constructor(statusCode: number, message?: string, code?: number) {
+    super(message);
+
+    this.name = 'HTTPError';
+    this.statusCode = statusCode;
+    this.code = code;
+
+    Object.setPrototypeOf(this, HTTPError.prototype);
+  }
+}

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+import { checkAndSetToken, handleAPIError, handleTokenError } from '@api/interceptors';
+import { BASE_URL } from '@constants/api';
+
+export const axiosInstance = axios.create({
+  baseURL: BASE_URL,
+  timeout: 5000,
+  withCredentials: true,
+  useAuth: true,
+});
+
+axiosInstance.interceptors.request.use(checkAndSetToken, handleAPIError);
+
+axiosInstance.interceptors.response.use((response) => response, handleTokenError);
+
+axiosInstance.interceptors.response.use((response) => response, handleAPIError);

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -1,0 +1,7 @@
+import 'axios';
+
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    useAuth?: boolean;
+  }
+}

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,0 +1,67 @@
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
+
+import { HTTPError } from '@api/HTTPError';
+import { axiosInstance } from '@api/axiosInstance';
+
+import { PATH } from '@constants/path';
+import { ACCESS_TOKEN_KEY, HTTP_STATUS_CODE } from '@constants/api';
+
+export interface ErrorResponseData {
+  statusCode?: number;
+  message?: string;
+  code?: number;
+}
+
+export const checkAndSetToken = (config: InternalAxiosRequestConfig) => {
+  if (!config.useAuth || !config.headers || config.headers.Authorization) return config;
+
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+
+  if (!accessToken) {
+    window.location.href = PATH.ROOT;
+    throw new Error('토큰이 유효하지 않습니다');
+  }
+
+  // eslint-disable-next-line
+  config.headers.Authorization = `Bearer ${accessToken}`;
+
+  return config;
+};
+
+export const handleTokenError = async (error: AxiosError<ErrorResponseData>) => {
+  const originalRequest = error.config;
+
+  if (!error.response || !originalRequest) throw new Error('에러가 발생했습니다.');
+
+  const { data, status } = error.response;
+
+  // TODO: 조건 - 특정 에러코드일때 액세스 토큰 재발급 후 다시 요청
+  if (true) {
+    // const { accessToken } = await -> TODO: 토큰 재발급 api
+    // originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+    // localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+
+    return axiosInstance(originalRequest);
+  }
+
+  // TODO: 조건 - 특정 에러코드일때 액세스 토큰 제거
+  if (true) {
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+
+    throw new HTTPError(status, data.message, data.code);
+  }
+
+  throw error;
+};
+
+export const handleAPIError = (error: AxiosError<ErrorResponseData>) => {
+  if (!error.response) throw new Error('에러가 발생했습니다.');
+
+  const { data, status } = error.response;
+
+  if (status >= HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR) {
+    throw new HTTPError(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR, data.message);
+  }
+
+  throw new HTTPError(status, data.message, data.code);
+};

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,77 @@
+export const BASE_URL = 'http://localhost:3000';
+
+const API_V1 = '/api/v1';
+
+const BASE_PATH_V1 = {
+  STUDY: `${API_V1}/studies`,
+  CODING_SPACE: `${API_V1}/coding-spaces`,
+  IDE: `${API_V1}/ide`,
+  USER: `${API_V1}/users`,
+  AUTH: `${API_V1}/auth`,
+  FILES: `${API_V1}/files`,
+};
+
+export const END_POINTS_V1 = {
+  STUDY: {
+    LIST: BASE_PATH_V1.STUDY,
+    PUBLIC_CREATE: `${BASE_PATH_V1.STUDY}/public`,
+    PRIVATE_CREATE: `${BASE_PATH_V1.STUDY}/private`,
+    PUBLIC_JOIN: `${BASE_PATH_V1.STUDY}/public/join`,
+    PRIVATE_JOIN: `${BASE_PATH_V1.STUDY}/private/join`,
+    EDIT: (studyId: string) => `${BASE_PATH_V1.STUDY}/${studyId}/edit`,
+    LEAVE: (studyId: string) => `${BASE_PATH_V1.STUDY}/${studyId}/leave`,
+    DELETE: (studyId: string) => `${BASE_PATH_V1.STUDY}/${studyId}/remove`,
+    DETAIL: (studyId: string) => `${BASE_PATH_V1.STUDY}/${studyId}`,
+    SPACE_LIST: (studyId: string) => `${BASE_PATH_V1.STUDY}/${studyId}`,
+    MEMBER_LIST: (studyId: string) => `${BASE_PATH_V1.STUDY}/${studyId}/members`,
+    INFO: (studyId: string) => `${BASE_PATH_V1.STUDY}/${studyId}/studyInfo`,
+    PARTICIPATED_STUDIES: (userId: string) => `${BASE_PATH_V1.STUDY}/me/${userId}`,
+  },
+
+  CODING_SPACE: {
+    CREATE: BASE_PATH_V1.CODING_SPACE,
+    JOIN: `${BASE_PATH_V1.CODING_SPACE}/join`,
+    PAGE: (codingSpaceId: string) => `${BASE_PATH_V1.CODING_SPACE}/${codingSpaceId}`,
+    TAB: (codingSpaceId: string) => `${BASE_PATH_V1.CODING_SPACE}/${codingSpaceId}/tab`,
+    ALL_TABS: (codingSpaceId: string) => `${BASE_PATH_V1.CODING_SPACE}/${codingSpaceId}/tabs`,
+    START: (codingSpaceId: string) => `${BASE_PATH_V1.CODING_SPACE}/${codingSpaceId}/start`,
+    TIMER: (codingSpaceId: string) => `${BASE_PATH_V1.CODING_SPACE}/${codingSpaceId}/timer`,
+    COMPLETE: (codingSpaceId: string) => `${BASE_PATH_V1.CODING_SPACE}/${codingSpaceId}/complete`,
+    TEST_CASE_UPDATE: (codingSpaceId: string) => `${BASE_PATH_V1.CODING_SPACE}/${codingSpaceId}/test-case`,
+    PARTICIPATED_CODING_SPACES: (userId: string) => `${BASE_PATH_V1.CODING_SPACE}/me/${userId}`,
+  },
+
+  IDE: {
+    RUN: `${BASE_PATH_V1.IDE}/run`,
+    SUBMIT: (fieldId: string) => `${BASE_PATH_V1.IDE}/${fieldId}/submit`,
+  },
+
+  USER: {
+    UPDATE_PROFILE: BASE_PATH_V1.USER,
+    MY_PAGE: (userId: string) => `${BASE_PATH_V1.USER}/me/${userId}`,
+  },
+
+  AUTH: {
+    OAUTH_LOGIN: `${BASE_PATH_V1.AUTH}/oauth-login`,
+    REFRESH_TOKEN: `${BASE_PATH_V1.AUTH}/re-issue`,
+  },
+
+  FILES: {
+    UPLOAD_PROFILE_IMAGE: `${BASE_PATH_V1.FILES}/profile-image`,
+  },
+} as const;
+
+export const STOMP_ENDPOINTS = {
+  SPACE_ALARM_SUBSCRIBE: (codingSpaceId: string) => `/sub/stomp/coding-space/${codingSpaceId}`,
+  TEST_CASE_SUBSCRIBE: (codingSpaceId: string) => `/sub/stomp/coding-spaces/${codingSpaceId}/test-case`,
+  EXECUTION_SUBSCRIBE: (ideId: string) => `/sub/stomp/ide-execution/${ideId}`,
+  RESULT_SUBSCRIBE: (ideId: string) => `/sub/stomp/ide-result/${ideId}`,
+} as const;
+
+export const ACCESS_TOKEN_KEY = 'ACCESS_TOKEN';
+
+export const HTTP_STATUS_CODE = {
+  SUCCESS: 200,
+  BAD_REQUEST: 400,
+  INTERNAL_SERVER_ERROR: 500,
+} as const;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,6 +1,6 @@
-export const BASE_URL = 'http://localhost:3000';
+export const BASE_URL = import.meta.env.VITE_API_URL;
 
-const API_V1 = '/api/v1';
+const API_V1 = import.meta.env.VITE_API_V1;
 
 const BASE_PATH_V1 = {
   STUDY: `${API_V1}/studies`,

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,3 @@
+export const PATH = {
+  ROOT: '/',
+} as const;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,21 @@
 {
   "compilerOptions": {
-    "lib": ["ES2017", "DOM"],
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": false,
+    "noEmit": true,
     "jsx": "react-jsx",
+
     "baseUrl": "./",
     "paths": {
       "@api/*": ["src/api/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ES2017", "DOM"],
     "jsx": "react-jsx",
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #33 

<br/>

## 🔎 작업 내용

- API 기본 URL 및 버전 정보를 환경 변수로 관리

- API 엔드포인트를 v1 기준으로 정리:
향후 API v2 추가 시 기존 구조를 그대로 유지하면서 쉽게 확장 가능

- HTTP 상태 코드 상수화:
백엔드에서 사용하는 상태 코드(200, 400, 500)만 사용

- 요청 인터셉터 (checkAndSetToken) 추가:
useAuth 옵션이 true일 경우, 요청 시 자동으로 액세스 토큰을 Authorization 헤더에 추가
토큰이 없을 경우 메인 페이지(PATH.ROOT)로 이동

- 응답 인터셉터 (handleTokenError, handleAPIError) 추가:
특정 에러 코드일 경우 토큰 재발급 후 요청을 다시 시도
만료된 토큰 또는 인증 오류 발생 시 로컬 스토리지에서 토큰 제거 후 에러 반환
서버 오류(500 이상) 발생 시 HTTPError를 던져 에러 핸들링 일관성 유지

- axiosInstance에 인터셉터 적용:
checkAndSetToken을 요청 인터셉터로 등록
handleTokenError, handleAPIError를 응답 인터셉터로 등록

TODO (추가 작업 필요)
- 토큰 재발급 API 연동 필요 (handleTokenError 부분)
- 에러 코드에 따른 상세 로직 구현 필요 (현재 if (true) 상태)

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

