### PR TITLE
COC-141 InputField 컴포넌트 구현

### DIFF
--- a/src/components/_common/molecules/InputField/index.tsx
+++ b/src/components/_common/molecules/InputField/index.tsx
@@ -1,4 +1,5 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, useState } from 'react';
+import { BsEyeSlash, BsEye } from 'react-icons/bs';
 import S from './style';
 
 interface InputFieldProps extends ComponentProps<'input'> {
@@ -8,6 +9,7 @@ interface InputFieldProps extends ComponentProps<'input'> {
 }
 
 export default function InputField({
+  type = 'text',
   label,
   description,
   value,
@@ -16,20 +18,32 @@ export default function InputField({
   error,
   required,
 }: InputFieldProps) {
+  const [isVisible, setIsVisible] = useState(type !== 'password');
+
+  const toggleVisibility = () => {
+    setIsVisible((prev) => !prev);
+  };
+
   return (
-    <S.InputWrapper>
+    <S.InputContainer>
       {label && <S.Label disabled={!!disabled}>{label}</S.Label>}
 
-      <S.Input
-        value={value}
-        placeholder={description}
-        onChange={onChange}
-        disabled={disabled}
-        required={required}
-        isError={!!error}
-      />
+      <S.InputWrapper>
+        <S.Input
+          type={isVisible ? 'text' : type}
+          value={value}
+          placeholder={description}
+          onChange={onChange}
+          disabled={disabled}
+          required={required}
+          isError={!!error}
+        />
+        {type === 'password' && value && (
+          <S.Icon onClick={toggleVisibility}>{isVisible ? <BsEye size={16} /> : <BsEyeSlash size={16} />}</S.Icon>
+        )}
+      </S.InputWrapper>
 
       {error && <S.ErrorText role='alert'>{error}</S.ErrorText>}
-    </S.InputWrapper>
+    </S.InputContainer>
   );
 }

--- a/src/components/_common/molecules/InputField/index.tsx
+++ b/src/components/_common/molecules/InputField/index.tsx
@@ -8,16 +8,7 @@ interface InputFieldProps extends ComponentProps<'input'> {
   error?: string;
 }
 
-export default function InputField({
-  type = 'text',
-  label,
-  description,
-  value,
-  onChange,
-  disabled,
-  error,
-  required,
-}: InputFieldProps) {
+export default function InputField({ type = 'text', label, description, error, ...props }: InputFieldProps) {
   const [isVisible, setIsVisible] = useState(type !== 'password');
 
   const toggleVisibility = () => {
@@ -26,19 +17,16 @@ export default function InputField({
 
   return (
     <S.InputContainer>
-      {label && <S.Label disabled={!!disabled}>{label}</S.Label>}
+      {label && <S.Label disabled={props.disabled}>{label}</S.Label>}
 
       <S.InputWrapper>
         <S.Input
           type={isVisible ? 'text' : type}
-          value={value}
           placeholder={description}
-          onChange={onChange}
-          disabled={disabled}
-          required={required}
           isError={!!error}
+          {...props}
         />
-        {type === 'password' && value && (
+        {type === 'password' && props.value && (
           <S.Icon onClick={toggleVisibility}>{isVisible ? <BsEye size={16} /> : <BsEyeSlash size={16} />}</S.Icon>
         )}
       </S.InputWrapper>

--- a/src/components/_common/molecules/InputField/index.tsx
+++ b/src/components/_common/molecules/InputField/index.tsx
@@ -1,0 +1,35 @@
+import { ComponentProps } from 'react';
+import S from './style';
+
+interface InputFieldProps extends ComponentProps<'input'> {
+  label?: string;
+  description?: string;
+  error?: string;
+}
+
+export default function InputField({
+  label,
+  description,
+  value,
+  onChange,
+  disabled,
+  error,
+  required,
+}: InputFieldProps) {
+  return (
+    <S.InputWrapper>
+      {label && <S.Label disabled={!!disabled}>{label}</S.Label>}
+
+      <S.Input
+        value={value}
+        placeholder={description}
+        onChange={onChange}
+        disabled={disabled}
+        required={required}
+        isError={!!error}
+      />
+
+      {error && <S.ErrorText role='alert'>{error}</S.ErrorText>}
+    </S.InputWrapper>
+  );
+}

--- a/src/components/_common/molecules/InputField/style.ts
+++ b/src/components/_common/molecules/InputField/style.ts
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  width: 100%;
+`;
+
+const Label = styled.label<{ disabled: boolean }>`
+  ${({ theme }) => theme.font.common.block};
+  color: ${({ theme, disabled }) => (disabled ? theme.color.gray[800] : theme.color.gray[950])};
+`;
+
+const Input = styled.input<{ isError: boolean }>`
+  color: ${({ theme }) => theme.color.gray[950]};
+  background-color: ${({ theme }) => theme.color.gray[50]};
+
+  ${({ theme }) => theme.font.common.block};
+  border: 1px solid ${({ theme, isError }) => (isError ? theme.color.triadic[400] : theme.color.gray[600])};
+  border-radius: 0.8rem;
+  padding: 1.35rem 1.8rem;
+  outline: none;
+
+  &::placeholder {
+    ${({ theme }) => theme.font.common.block};
+    color: ${({ theme }) => theme.color.gray[700]};
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.color.gray[200]};
+    border-color: ${({ theme }) => theme.color.gray[500]};
+  }
+`;
+
+const ErrorText = styled.p`
+  ${({ theme }) => theme.font.common.small};
+  color: ${({ theme }) => theme.color.triadic[400]};
+`;
+
+const S = {
+  InputWrapper,
+  Label,
+  Input,
+  ErrorText,
+};
+
+export default S;

--- a/src/components/_common/molecules/InputField/style.ts
+++ b/src/components/_common/molecules/InputField/style.ts
@@ -1,11 +1,15 @@
 import styled from '@emotion/styled';
 
-const InputWrapper = styled.div`
+const InputContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 
   width: 100%;
+`;
+
+const InputWrapper = styled.div`
+  position: relative;
 `;
 
 const Label = styled.label<{ disabled: boolean }>`
@@ -14,6 +18,8 @@ const Label = styled.label<{ disabled: boolean }>`
 `;
 
 const Input = styled.input<{ isError: boolean }>`
+  width: 100%;
+
   color: ${({ theme }) => theme.color.gray[950]};
   background-color: ${({ theme }) => theme.color.gray[50]};
 
@@ -34,15 +40,24 @@ const Input = styled.input<{ isError: boolean }>`
   }
 `;
 
+const Icon = styled.div`
+  position: absolute;
+  top: 50%;
+  right: 2%;
+  transform: translateY(-50%);
+`;
+
 const ErrorText = styled.p`
   ${({ theme }) => theme.font.common.small};
   color: ${({ theme }) => theme.color.triadic[400]};
 `;
 
 const S = {
+  InputContainer,
   InputWrapper,
   Label,
   Input,
+  Icon,
   ErrorText,
 };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #36 

<br/>

## 🔎 작업 내용

- label: 입력 필드 위에 표시될 라벨 (선택 사항)
- description: 플레이스홀더 역할을 하는 설명 (선택 사항)
- error: 유효성 검사 실패 시 표시될 에러 메시지 (선택 사항)
- type="password"인 경우, 입력 값이 있을 때 비밀번호 가시성 전환 버튼이 표시됨 (type 설정하지 않으면 기본 'text'로)
- 기본 input 속성(value, onChange, disabled, required 등)은 props로 전달 가능

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
