### PR TITLE
COC-64: 코딩 스페이스 피드백 페이지, 종료 페이지 구현

### DIFF
--- a/src/api/domain/space.ts
+++ b/src/api/domain/space.ts
@@ -1,6 +1,7 @@
 import { axiosInstance } from '@api/axiosInstance';
 import { END_POINTS_V1 } from '@constants/api';
-import { CreateSpaceData, SpaceData, SpaceListParams, TestCaseIO } from '@customTypes/space';
+
+import { CreateSpaceData, SpaceData, SpaceListParams, TestCaseIO, Tab } from '@customTypes/space';
 
 const spaceApi = {
   getInfo: async (codingSpaceId: string) => {
@@ -29,6 +30,12 @@ const spaceApi = {
 
   start: async (codingSpaceId: string, studyId: string) => {
     await axiosInstance.post(END_POINTS_V1.CODING_SPACE.START(codingSpaceId), studyId);
+
+    return codingSpaceId;
+  },
+
+  complete: async (codingSpaceId: string, tabData: Tab[]) => {
+    await axiosInstance.post(END_POINTS_V1.CODING_SPACE.COMPLETE(codingSpaceId), tabData);
 
     return codingSpaceId;
   },

--- a/src/components/Space/ExecutionPanel/index.tsx
+++ b/src/components/Space/ExecutionPanel/index.tsx
@@ -28,7 +28,7 @@ export default function ExecutionPanel({ setInput, output, disabled }: Execution
       {selectedTab === 'INPUT' ? (
         <S.Runner
           placeholder='여기에 입력하세요.'
-          onChange={(e) => setInput?.(e.target.value)}
+          onChange={(e) => setInput(e.target.value)}
         />
       ) : (
         <S.RunnerResult

--- a/src/components/Space/SpaceFooter/index.tsx
+++ b/src/components/Space/SpaceFooter/index.tsx
@@ -1,7 +1,7 @@
 import { BsPlus } from 'react-icons/bs';
 import IconButton from '@components/_common/atoms/IconButton';
 import Button from '@components/_common/atoms/Button';
-import { FOOTER_ACTIONS } from '@constants/space';
+import { FOOTER_ACTIONS, STATUS } from '@constants/space';
 import { TestCaseData } from '@customTypes/space';
 import { useModalStore } from '@stores/useModalStore';
 import S from './style';
@@ -35,7 +35,7 @@ export default function SpaceFooter({ codingSpaceId, status, testCases, onCodeRu
           shape='round'
           onClick={handleOpenTestCase}
         >
-          <BsPlus />
+          {(status === STATUS.RUNNING || status === STATUS.FEEDBACK) && <BsPlus />}
         </IconButton>
       </S.TestCaseButton>
 

--- a/src/components/Space/SpaceNavbar/index.tsx
+++ b/src/components/Space/SpaceNavbar/index.tsx
@@ -5,11 +5,11 @@ import { ROUTES } from '@constants/path';
 import { STATUS_ACTIONS, STATUS } from '@constants/space';
 
 import useStartSpace from '@hooks/space/useStartSpace';
-
+import useCompleteSpace from '@hooks/space/useCompleteSpace';
 import IconButton from '@components/_common/atoms/IconButton';
 import Button from '@components/_common/atoms/Button';
 import Timer from '@components/_common/atoms/Timer';
-
+import { Tab } from '@customTypes/space';
 import S from './style';
 
 interface SpaceNavbarProps {
@@ -19,30 +19,48 @@ interface SpaceNavbarProps {
   isLeader: boolean;
   name: string;
   timer?: number;
+  tabData?: Tab[];
 }
 
-export default function SpaceNavbar({ codingSpaceId, studyId, status, isLeader, name, timer }: SpaceNavbarProps) {
+export default function SpaceNavbar({
+  codingSpaceId,
+  studyId,
+  status,
+  isLeader,
+  name,
+  timer,
+  tabData,
+}: SpaceNavbarProps) {
   const navigate = useNavigate();
   const { startSpaceMutate } = useStartSpace();
+  const { completeSpaceMutate } = useCompleteSpace();
   const actionLabel = STATUS_ACTIONS[status]?.label;
 
   const handleStart = () => {
     if (status === STATUS.WAITING) {
       startSpaceMutate.mutate({ codingSpaceId, studyId });
     }
+    if (status === STATUS.FEEDBACK) {
+      completeSpaceMutate.mutate({ codingSpaceId, tabData });
+    }
+    if (status === STATUS.FINISHED) {
+      navigate(ROUTES.STUDY.DETAIL({ studyId }));
+    }
   };
 
   return (
     <S.Container>
       <S.LeftSection>
-        <IconButton
-          content='돌아가기'
-          align='center'
-          color='none'
-          onClick={() => navigate(ROUTES.STUDY.DETAIL({ studyId }))}
-        >
-          <BsArrowLeft />
-        </IconButton>
+        {status !== STATUS.FINISHED && (
+          <IconButton
+            content='돌아가기'
+            align='center'
+            color='none'
+            onClick={() => navigate(ROUTES.STUDY.DETAIL({ studyId }))}
+          >
+            <BsArrowLeft />
+          </IconButton>
+        )}
         <S.Name>{name}</S.Name>
       </S.LeftSection>
       <S.RightSection>

--- a/src/components/Space/UserTabList/UserTab/index.tsx
+++ b/src/components/Space/UserTabList/UserTab/index.tsx
@@ -3,12 +3,16 @@ import S, { UserTabColor } from './style';
 interface UserTabProps {
   color: UserTabColor;
   name: string;
+  isSelected: boolean;
   onClick?: () => void;
 }
 
-export default function UserTab({ color, name, onClick }: UserTabProps) {
+export default function UserTab({ color, name, onClick, isSelected }: UserTabProps) {
   return (
-    <S.UserTab onClick={onClick}>
+    <S.UserTab
+      isSelected={isSelected}
+      onClick={onClick}
+    >
       <S.UserName color={color}>{name}</S.UserName>
       <S.Dot color={color} />
     </S.UserTab>

--- a/src/components/Space/UserTabList/UserTab/style.ts
+++ b/src/components/Space/UserTabList/UserTab/style.ts
@@ -33,7 +33,7 @@ const backgroundColorStyles: { [key in UserTabColor]: (theme: Theme) => Serializ
   `,
 };
 
-const UserTab = styled.div`
+const UserTab = styled.div<{ isSelected: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -46,6 +46,7 @@ const UserTab = styled.div`
   border-right: 1px solid ${({ theme }) => theme.color.gray[600]};
 
   cursor: pointer;
+  border-bottom: ${({ isSelected, theme }) => (isSelected ? `3px solid ${theme.color.analogous[300]}` : 'none')};
 `;
 
 const UserName = styled.span<{ color: UserTabColor }>`

--- a/src/components/Space/UserTabList/index.tsx
+++ b/src/components/Space/UserTabList/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { UserData } from '@customTypes/user';
 import { UserTabColor } from './UserTab/style';
 import UserTab from './UserTab';
@@ -11,6 +12,13 @@ interface UserTabListProps {
 }
 
 export default function UserTabList({ users, selectUser }: UserTabListProps) {
+  const [selectedUserId, setSelectedUserId] = useState<number>(users[0]?.id);
+
+  const handleUserClick = (userId: number) => {
+    setSelectedUserId(userId);
+    selectUser?.(userId);
+  };
+
   return (
     <S.Container>
       {users.map((user, index) => (
@@ -18,7 +26,8 @@ export default function UserTabList({ users, selectUser }: UserTabListProps) {
           key={user.id}
           color={tabColors[index % tabColors.length]}
           name={user.nickName}
-          onClick={() => selectUser(user.id)}
+          isSelected={user.id === selectedUserId}
+          onClick={() => handleUserClick(user.id)}
         />
       ))}
     </S.Container>

--- a/src/hooks/space/useCompleteSpace.ts
+++ b/src/hooks/space/useCompleteSpace.ts
@@ -1,0 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+
+import spaceApi from '@api/domain/space';
+import { useModalStore } from '@stores/useModalStore';
+import { WAITING_INFO } from '@constants/modal';
+import { Tab } from '@customTypes/space';
+
+export default function useCompleteSpace() {
+  const navigate = useNavigate();
+  const { open } = useModalStore();
+
+  const completeSpaceMutate = useMutation({
+    mutationFn: ({ codingSpaceId, tabData }: { codingSpaceId: string; tabData: Tab[] }) =>
+      spaceApi.complete(codingSpaceId, tabData),
+    onSuccess: (codingSpaceId) => {
+      open('waiting', {
+        label: WAITING_INFO.exit.label,
+        description: WAITING_INFO.exit.description,
+        navigate: navigate(WAITING_INFO.exit.navigate(codingSpaceId)),
+      });
+    },
+  });
+  return { completeSpaceMutate };
+}

--- a/src/mocks/data/space.ts
+++ b/src/mocks/data/space.ts
@@ -8,7 +8,7 @@ export const getSpaceResponse = {
       id: 1,
       studyId: 1,
       name: '스페이스 제목입니다.',
-      status: '진행',
+      status: '종료',
       language: 'javascript',
       referenceUrl: 'url',
       description: `
@@ -127,6 +127,51 @@ export const getTabResponse = {
         profileImageUrl: 'https://cdn.cocomu.co.kr/images/default/profile.png',
       },
     },
+  },
+};
+
+export const getAllTabsResponse = {
+  code: 1100,
+  message: '코딩 스페이스 입장에 성공하였습니다.',
+  result: {
+    tabs: [
+      {
+        tabId: 'UUID1',
+        code: '1',
+        user: {
+          id: 1,
+          nickName: '코코1',
+          profileImageUrl: 'https://cdn.domain.com/images/*.png',
+        },
+      },
+      {
+        tabId: 'UUID2',
+        code: '2',
+        user: {
+          id: 2,
+          nickName: '코코2',
+          profileImageUrl: 'https://cdn.domain.com/images/*.png',
+        },
+      },
+      {
+        tabId: 'UUID3',
+        code: '3',
+        user: {
+          id: 3,
+          nickName: '코코3',
+          profileImageUrl: 'https://cdn.domain.com/images/*.png',
+        },
+      },
+      {
+        tabId: 'UUID4',
+        code: '4',
+        user: {
+          id: 4,
+          nickName: '코코4',
+          profileImageUrl: 'https://cdn.domain.com/images/*.png',
+        },
+      },
+    ],
   },
 };
 
@@ -353,4 +398,14 @@ export const getSpaceListResponse = {
 export const getSpaceListErrorResponse = {
   code: 4200,
   message: '코딩 스페이스 조회에 실패했습니다.',
+};
+
+export const completeSpaceResponse = {
+  code: 1200,
+  message: '코딩 스페이스 종료에 성공했습니다.',
+};
+
+export const completeSpaceErrorResponse = {
+  code: 4200,
+  message: '피드백 종료에 실패했습니다.',
 };

--- a/src/mocks/handlers/ide.ts
+++ b/src/mocks/handlers/ide.ts
@@ -5,9 +5,8 @@ import { ideRunResponse, ideSubmitResponse } from '@mocks/data/ide';
 export const ideRunHandlers = [
   http.post(`${BASE_URL}${END_POINTS_V1.IDE.RUN}`, async ({ request }) => {
     const body = (await request.json()) as { bodyData };
-    const { bodyData } = body;
 
-    if (!bodyData) {
+    if (!body) {
       return new HttpResponse(JSON.stringify({ message: ' Invalid request' }), {
         status: HTTP_STATUS_CODE.BAD_REQUEST,
       });
@@ -23,9 +22,8 @@ export const ideSubmitHandler = [
   http.post(`${BASE_URL}${END_POINTS_V1.IDE.SUBMIT(':ideID')}`, async ({ params, request }) => {
     const { ideID } = params;
     const body = (await request.json()) as { bodyData };
-    const { bodyData } = body;
 
-    if (!ideID || !bodyData) {
+    if (!ideID || !body) {
       return new HttpResponse(JSON.stringify({ message: ' Invalid request' }), {
         status: HTTP_STATUS_CODE.BAD_REQUEST,
       });

--- a/src/mocks/handlers/space.ts
+++ b/src/mocks/handlers/space.ts
@@ -6,12 +6,15 @@ import {
   getSpaceResponse,
   getTabErrorResponse,
   getTabResponse,
+  getAllTabsResponse,
   spaceStartErrorResponse,
   spaceStartResponse,
   updateTestCaseErrorResponse,
   updateTestCaseResponse,
   getSpaceListErrorResponse,
   getSpaceListResponse,
+  completeSpaceResponse,
+  completeSpaceErrorResponse,
 } from '@mocks/data/space';
 import { BASE_URL, END_POINTS_V1, HTTP_STATUS_CODE } from '@constants/api';
 import { CreateSpaceData, TestCaseIO } from '@customTypes/space';
@@ -41,6 +44,20 @@ export const spaceHandlers = [
     }
 
     return new HttpResponse(JSON.stringify(getTabResponse), {
+      status: HTTP_STATUS_CODE.SUCCESS,
+    });
+  }),
+
+  http.get(`${BASE_URL}${END_POINTS_V1.CODING_SPACE.ALL_TABS(':codingSpaceId')}`, async ({ params }) => {
+    const { codingSpaceId } = params;
+
+    if (!codingSpaceId) {
+      return new HttpResponse(JSON.stringify(getTabErrorResponse), {
+        status: HTTP_STATUS_CODE.BAD_REQUEST,
+      });
+    }
+
+    return new HttpResponse(JSON.stringify(getAllTabsResponse), {
       status: HTTP_STATUS_CODE.SUCCESS,
     });
   }),
@@ -91,7 +108,6 @@ export const spaceHandlers = [
       });
     },
   ),
-
   http.get(`${BASE_URL}${END_POINTS_V1.CODING_SPACE.LIST(':studyId')}`, async ({ request, params }) => {
     const { studyId } = params;
     if (!studyId || Number.isNaN(Number(studyId))) {
@@ -120,6 +136,21 @@ export const spaceHandlers = [
     };
 
     return new HttpResponse(JSON.stringify(response), {
+      status: HTTP_STATUS_CODE.SUCCESS,
+    });
+  }),
+
+  http.post(`${BASE_URL}${END_POINTS_V1.CODING_SPACE.COMPLETE(':codingSpaceId')}`, async ({ params, request }) => {
+    const body = await request.json();
+    const { codingSpaceId } = params;
+
+    if (!body || !codingSpaceId) {
+      return new HttpResponse(JSON.stringify(completeSpaceErrorResponse), {
+        status: HTTP_STATUS_CODE.BAD_REQUEST,
+      });
+    }
+
+    return new HttpResponse(JSON.stringify(completeSpaceResponse), {
       status: HTTP_STATUS_CODE.SUCCESS,
     });
   }),

--- a/src/pages/Space/SpaceFeedback/style.ts
+++ b/src/pages/Space/SpaceFeedback/style.ts
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+
+interface sizeStyleProps {
+  height?: number;
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+`;
+
+const CodingContainer = styled.div<sizeStyleProps>`
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  width: 100%;
+  height: ${({ height }) => `${height}%` || '70%'};
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  user-select: none;
+`;
+
+const MonacoContainer = styled.div`
+  display: flex;
+  flex-grow: 1;
+  overflow: auto;
+`;
+
+const S = { Container, CodingContainer, MonacoContainer };
+
+export default S;

--- a/src/pages/Space/SpaceFinish/index.tsx
+++ b/src/pages/Space/SpaceFinish/index.tsx
@@ -1,32 +1,23 @@
 import { useEffect, useState } from 'react';
 import { useOutletContext, useParams } from 'react-router-dom';
-
-import { useDraggable } from '@hooks/utils/useDraggable';
 import useGetAllTabs from '@hooks/space/useGetAllTabs';
-
-import { SpaceOutletProps } from '@customTypes/space';
-
 import MonacoEditor from '@monaco-editor/react';
-
-import ResizablePanel from '@components/Space/ResizablePanel';
-import ExecutionPanel from '@components/Space/ExecutionPanel';
 import UserTabList from '@components/Space/UserTabList';
+import { SpaceOutletProps } from '@customTypes/space';
 import Loading from '@pages/Loading';
-
 import S from './style';
 
-export default function SpaceFeedBack() {
+export default function SpaceFinish() {
   const { codingSpaceId } = useParams();
-  const outletData = useOutletContext<SpaceOutletProps>();
   const { data, isLoading } = useGetAllTabs(codingSpaceId);
+  const outletData = useOutletContext<SpaceOutletProps>();
 
   const [tab, setTab] = useState(null);
   const [tabCodeMap, setTabCodeMap] = useState<Record<string, string>>({});
 
-  const { value: height, containerRef, handleMouseDown } = useDraggable({ direction: 'y', initialValue: 70 });
-
   useEffect(() => {
     if (data?.tabs?.length) {
+      console.log(data);
       setTab(data.tabs[0]);
 
       setTabCodeMap(
@@ -41,48 +32,18 @@ export default function SpaceFeedBack() {
     }
   }, [data]);
 
-  useEffect(() => {
-    if (tabCodeMap) {
-      const tabList = Object.entries(tabCodeMap).map(([id, code]) => ({
-        id,
-        code,
-      }));
-      outletData?.setCompleteTabs(tabList);
-    }
-  }, [outletData, tabCodeMap]);
-
-  useEffect(() => {
-    if (tab) {
-      outletData?.setTabInfo({
-        id: tab.tabId,
-        code: Object.prototype.hasOwnProperty.call(tabCodeMap, tab?.tabId) ? tabCodeMap[tab?.tabId] : tab?.code,
-      });
-    }
-  }, [tab, tabCodeMap, outletData]);
-
-  const handleCodeChange = (value: string) => {
-    if (tab) {
-      setTabCodeMap((prev) => ({
-        ...prev,
-        [tab.tabId]: value,
-      }));
-    }
-    outletData?.setTabInfo((prev) => ({ ...prev, code: value }));
-  };
-
   const selectUser = (userId: number) => {
     const userTab = data?.tabs.find((tabData) => tabData.user.id === userId);
-
+    console.log(userTab);
     if (userTab) {
       setTab(userTab);
     }
   };
 
   if (isLoading) return <Loading />;
-
   return (
-    <S.Container ref={containerRef}>
-      <S.CodingContainer height={height}>
+    <S.Container>
+      <S.CodingContainer>
         <UserTabList
           users={data?.tabs.map((tabData) => tabData.user) || []}
           selectUser={selectUser}
@@ -95,17 +56,12 @@ export default function SpaceFeedBack() {
               minimap: { enabled: false },
               scrollBeyondLastLine: false,
               automaticLayout: true,
+              readOnly: true,
             }}
             value={Object.prototype.hasOwnProperty.call(tabCodeMap, tab?.tabId) ? tabCodeMap[tab?.tabId] : tab?.code}
-            onChange={handleCodeChange}
           />
         </S.MonacoContainer>
       </S.CodingContainer>
-      <ResizablePanel
-        direction='x'
-        onMouseDown={handleMouseDown}
-      />
-      <ExecutionPanel setInput={outletData?.setInputData} />
     </S.Container>
   );
 }

--- a/src/pages/Space/SpaceFinish/style.ts
+++ b/src/pages/Space/SpaceFinish/style.ts
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+`;
+
+const CodingContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  user-select: none;
+`;
+
+const MonacoContainer = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+const S = { Container, CodingContainer, MonacoContainer };
+
+export default S;

--- a/src/pages/Space/SpaceRunning/index.tsx
+++ b/src/pages/Space/SpaceRunning/index.tsx
@@ -14,38 +14,43 @@ import ResizablePanel from '@components/Space/ResizablePanel';
 import ExecutionPanel from '@components/Space/ExecutionPanel';
 import UserTabList from '@components/Space/UserTabList';
 
-import Loading from '@pages/Loading';
-
 import S from './style';
 
 export default function SpaceRunning() {
   const { codingSpaceId } = useParams();
   const outletData = useOutletContext<SpaceOutletProps>();
-  const { data, isLoading } = useGetTab(codingSpaceId);
 
-  const [code, setCode] = useState(data?.tab?.code);
+  const [code, setCode] = useState('');
+
+  const { data } = useGetTab(codingSpaceId);
+  const [tab, setTab] = useState(data);
 
   const { value: height, containerRef, handleMouseDown } = useDraggable({ direction: 'y', initialValue: 70 });
 
   useEffect(() => {
     if (!data?.tab) return;
 
-    outletData?.setTabInfo((prev) => ({ ...prev, id: data?.tab?.id }));
+    if (data) {
+      setTab(data);
+    }
 
-    setCode(data?.tab?.code || DEFAULT_CODE[outletData?.language?.toLocaleLowerCase()] || '');
-  }, [outletData, data?.tab]);
+    outletData?.setTabInfo({
+      id: tab?.tab?.id,
+      code: tab?.tab?.code || DEFAULT_CODE[outletData?.language?.toLocaleLowerCase()] || '',
+    });
+
+    setCode(tab?.tab?.code || DEFAULT_CODE[outletData?.language?.toLocaleLowerCase()] || '');
+  }, [outletData, tab?.tab, data]);
 
   const handleCodeChange = (value: string) => {
     setCode(value);
     outletData?.setTabInfo((prev) => ({ ...prev, code: value }));
   };
 
-  if (isLoading) return <Loading />;
-
   return (
     <S.Container ref={containerRef}>
       <S.CodingContainer height={height}>
-        <UserTabList users={data?.tab?.user ? [data.tab.user] : []} />
+        <UserTabList users={tab?.tab?.user ? [tab.tab.user] : []} />
 
         <S.MonacoContainer>
           <MonacoEditor

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -25,7 +25,7 @@ const SpaceCreate = lazy(() => import('@pages/Space/SpaceCreate'));
 const SpaceWaiting = lazy(() => import('@pages/Space/SpaceWaiting'));
 const SpaceRunning = lazy(() => import('@pages/Space/SpaceRunning'));
 const SpaceFeedback = lazy(() => import('@pages/Space/SpaceFeedback'));
-
+const SpaceFinish = lazy(() => import('@pages/Space/SpaceFinish'));
 const router = createBrowserRouter(
   [
     {
@@ -69,7 +69,8 @@ const router = createBrowserRouter(
           path: PATH.SPACE.DETAIL,
           element: <SpaceDetail />,
           children: [
-            { index: true, element: <SpaceWaiting /> },
+            { index: true, element: <SpaceFinish /> },
+            { path: PATH.SPACE.WAITING, element: <SpaceWaiting /> },
             { path: PATH.SPACE.RUNNING, element: <SpaceRunning /> },
             { path: PATH.SPACE.FEEDBACK, element: <SpaceFeedback /> },
           ],

--- a/src/types/space.ts
+++ b/src/types/space.ts
@@ -47,11 +47,18 @@ export interface TestCaseData extends SubmitTestCase {
   type?: TestCaseType;
 }
 
+export interface Tab {
+  id: string;
+  code: string;
+}
+
 export interface SpaceOutletProps {
+  status?: string;
   language?: string;
   totalUserCount?: number;
   setTabInfo?: Dispatch<SetStateAction<{ code: string; id: string }>>;
   setInputData?: Dispatch<SetStateAction<string>>;
+  setCompleteTabs?: Dispatch<SetStateAction<Tab[]>>;
 }
 
 export interface CreateSpaceFormData extends Record<string, string | number> {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #95 

<br/>

## 🔎 작업 내용

-  피드백 페이지
- 종료 페이지 
-  모든 탭 조회 api 구현
- 피드백 종료 api 구현

<br/>
space mock 데이터에서 getSpaceResponse status부분 변경되는 페이지에 따라서 대기, 진행, 피드백, 종료로 변경

![image](https://github.com/user-attachments/assets/eeced8bf-479d-40af-9c13-60672a869a48)

![image](https://github.com/user-attachments/assets/7e371a31-43ba-445d-86e3-612388f97e04)

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
