### PR TITLE
COC-180 스터디 나가기 구현

### DIFF
--- a/src/api/domain/study.ts
+++ b/src/api/domain/study.ts
@@ -66,6 +66,11 @@ const studyApi = {
 
     return data.result;
   },
+
+  leave: async (studyId: string) => {
+    const { data } = await axiosInstance.post(END_POINTS_V1.STUDY.LEAVE(studyId));
+    return data;
+  },
 };
 
 export default studyApi;

--- a/src/components/Modal/Leave/index.tsx
+++ b/src/components/Modal/Leave/index.tsx
@@ -4,10 +4,10 @@ import { LeaveProps } from '@customTypes/modal';
 import S from './style';
 
 export default function LeaveModal({ studyId, name, onClose, navigate }: LeaveProps) {
-  const leaveStudy = useLeaveStudy({ navigate });
+  const { leaveStudyMutate } = useLeaveStudy({ navigate });
 
   const handleConfirm = () => {
-    leaveStudy.mutate(studyId);
+    leaveStudyMutate.mutate(studyId);
     onClose();
   };
 

--- a/src/components/Modal/Leave/index.tsx
+++ b/src/components/Modal/Leave/index.tsx
@@ -38,6 +38,7 @@ export default function LeaveModal({ studyId, name, onClose, navigateToStudyList
         <Button
           color='white'
           size='md'
+          borderColor='triadic'
           onClick={onClose}
         >
           취소

--- a/src/components/Modal/Leave/index.tsx
+++ b/src/components/Modal/Leave/index.tsx
@@ -1,26 +1,14 @@
 import Button from '@components/_common/atoms/Button';
 import useLeaveStudy from '@hooks/study/useLeaveStudy';
+import { LeaveProps } from '@customTypes/modal';
 import S from './style';
 
-interface LeaveModalProps {
-  studyId: string;
-  name: string;
-  onClose: () => void;
-  navigateToStudyList: () => void;
-}
-
-export default function LeaveModal({ studyId, name, onClose, navigateToStudyList }: LeaveModalProps) {
-  const leaveStudy = useLeaveStudy();
+export default function LeaveModal({ studyId, name, onClose, navigate }: LeaveProps) {
+  const leaveStudy = useLeaveStudy({ navigate });
 
   const handleConfirm = () => {
-    leaveStudy.mutate(studyId, {
-      onSuccess: () => {
-        onClose();
-        if (navigateToStudyList) {
-          navigateToStudyList();
-        }
-      },
-    });
+    leaveStudy.mutate(studyId);
+    onClose();
   };
 
   return (

--- a/src/components/Modal/Leave/index.tsx
+++ b/src/components/Modal/Leave/index.tsx
@@ -1,0 +1,48 @@
+import Button from '@components/_common/atoms/Button';
+import useLeaveStudy from '@hooks/study/useLeaveStudy';
+import S from './style';
+
+interface LeaveModalProps {
+  studyId: string;
+  name: string;
+  onClose: () => void;
+  navigateToStudyList: () => void;
+}
+
+export default function LeaveModal({ studyId, name, onClose, navigateToStudyList }: LeaveModalProps) {
+  const leaveStudy = useLeaveStudy();
+
+  const handleConfirm = () => {
+    leaveStudy.mutate(studyId, {
+      onSuccess: () => {
+        onClose();
+        if (navigateToStudyList) {
+          navigateToStudyList();
+        }
+      },
+    });
+  };
+
+  return (
+    <S.Container>
+      <S.Description>{name}</S.Description>
+      <S.Instruction>스터디에서 나가시겠습니까?</S.Instruction>
+      <S.ButtonWrapper>
+        <Button
+          color='triadic'
+          size='md'
+          onClick={handleConfirm}
+        >
+          확인
+        </Button>
+        <Button
+          color='white'
+          size='md'
+          onClick={onClose}
+        >
+          취소
+        </Button>
+      </S.ButtonWrapper>
+    </S.Container>
+  );
+}

--- a/src/components/Modal/Leave/style.ts
+++ b/src/components/Modal/Leave/style.ts
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4rem;
+
+  padding: 6.6rem 15rem 6.2rem 15rem;
+`;
+
+const Description = styled.p`
+  ${({ theme }) => theme.font.heading[300]};
+  color: ${({ theme }) => theme.color.gray[900]};
+`;
+
+const Instruction = styled.p`
+  ${({ theme }) => theme.font.heading[500]};
+  color: ${({ theme }) => theme.color.gray[950]};
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-self: center;
+  gap: 1.3rem;
+
+  height: 4.2rem;
+  margin-top: 1rem;
+`;
+
+const S = { Container, Description, Instruction, ButtonWrapper };
+export default S;

--- a/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
+++ b/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
@@ -41,7 +41,7 @@ export default function DescriptionHeader({ isLeader, isStudy, leader, studyId }
     open('leave', {
       studyId: String(studyId),
       name: leader.nickname,
-      navigate: () => navigate(ROUTES.STUDY.LIST()),
+      navigate: () => navigate(ROUTES.ROOT()),
     });
   };
 

--- a/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
+++ b/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
@@ -10,6 +10,7 @@ import DropdownItem from '@components/_common/atoms/DropdownItem';
 import { STUDY_EDIT_DROPDOWN_LABELS } from '@constants/common';
 import { ROUTES } from '@constants/path';
 import { UserData } from '@customTypes/user';
+import { useModalStore } from '@stores/useModalStore';
 
 import S from './style';
 
@@ -23,6 +24,7 @@ interface DescriptionHeaderProps {
 export default function DescriptionHeader({ isLeader, isStudy, leader, studyId }: DescriptionHeaderProps) {
   const navigate = useNavigate();
   const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const { open, close } = useModalStore();
 
   const handleDropdownToggle = () => setDropdownOpen((prev) => !prev);
 
@@ -35,7 +37,14 @@ export default function DescriptionHeader({ isLeader, isStudy, leader, studyId }
     setDropdownOpen(false);
   };
 
-  const handleLeave = () => {};
+  const handleLeaveClick = () => {
+    open('leave', {
+      studyId: String(studyId),
+      name: leader.nickname,
+      onClose: close,
+      navigateToStudyList: () => navigate(ROUTES.STUDY.LIST()),
+    });
+  };
 
   return (
     <S.Header>
@@ -72,7 +81,7 @@ export default function DescriptionHeader({ isLeader, isStudy, leader, studyId }
           <Button
             color='triadic'
             size='md'
-            onClick={handleLeave}
+            onClick={handleLeaveClick}
           >
             스터디 나가기
           </Button>

--- a/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
+++ b/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
@@ -24,7 +24,7 @@ interface DescriptionHeaderProps {
 export default function DescriptionHeader({ isLeader, isStudy, leader, studyId }: DescriptionHeaderProps) {
   const navigate = useNavigate();
   const [isDropdownOpen, setDropdownOpen] = useState(false);
-  const { open, close } = useModalStore();
+  const { open } = useModalStore();
 
   const handleDropdownToggle = () => setDropdownOpen((prev) => !prev);
 
@@ -41,8 +41,7 @@ export default function DescriptionHeader({ isLeader, isStudy, leader, studyId }
     open('leave', {
       studyId: String(studyId),
       name: leader.nickname,
-      onClose: close,
-      navigateToStudyList: () => navigate(ROUTES.STUDY.LIST()),
+      navigate: () => navigate(ROUTES.STUDY.LIST()),
     });
   };
 

--- a/src/components/_common/atoms/Button/index.tsx
+++ b/src/components/_common/atoms/Button/index.tsx
@@ -1,7 +1,10 @@
 import { PropsWithChildren } from 'react';
 import S, { ButtonStyleProps } from './style';
 
-export type ButtonProps = PropsWithChildren<React.ComponentProps<'button'> & ButtonStyleProps>;
+export type ButtonProps = PropsWithChildren<
+  React.ComponentProps<'button'> &
+    Omit<ButtonStyleProps, 'borderColor'> & { borderColor?: ButtonStyleProps['borderColor'] }
+>;
 
 export default function Button({
   children,
@@ -10,6 +13,7 @@ export default function Button({
   size = 'md',
   color = 'white',
   shape = 'default',
+  borderColor = 'primary',
 }: ButtonProps) {
   return (
     <S.Button
@@ -18,6 +22,7 @@ export default function Button({
       size={size}
       color={color}
       shape={shape}
+      borderColor={borderColor}
     >
       {children}
     </S.Button>

--- a/src/components/_common/atoms/Button/style.ts
+++ b/src/components/_common/atoms/Button/style.ts
@@ -4,11 +4,13 @@ import styled from '@emotion/styled';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 export type ButtonColor = 'white' | 'primary' | 'secondary' | 'analogous' | 'triadic';
 export type ButtonShape = 'default' | 'round';
+export type ButtonBorderColor = 'primary' | 'triadic';
 
 export interface ButtonStyleProps {
   size: ButtonSize;
   color: ButtonColor;
   shape?: ButtonShape;
+  borderColor?: ButtonBorderColor; // 선택적 속성으로 변경
 }
 
 const commonStyles = (theme: Theme) => css`
@@ -46,11 +48,11 @@ const sizeStyles = {
   `,
 };
 
-const colorStyles: { [key in ButtonColor]: (theme: Theme) => SerializedStyles } = {
-  white: (theme: Theme) => css`
-    color: ${theme.color.primary[300]};
+const colorStyles: { [key in ButtonColor]: (theme: Theme, borderColor?: ButtonBorderColor) => SerializedStyles } = {
+  white: (theme: Theme, borderColor = 'primary') => css`
+    color: ${borderColor === 'triadic' ? theme.color.triadic[400] : theme.color.primary[300]};
     background-color: ${theme.color.gray[50]};
-    border: 1px solid ${theme.color.primary[300]};
+    border: 1px solid ${borderColor === 'triadic' ? theme.color.triadic[400] : theme.color.primary[300]};
   `,
   primary: (theme: Theme) => css`
     color: ${theme.color.gray[50]};
@@ -81,8 +83,8 @@ const shapeStyles = (shape: ButtonShape = 'default') => css`
 const Button = styled.button<ButtonStyleProps>`
   ${({ theme }) => commonStyles(theme)}
   ${({ size, theme }) => sizeStyles[size](theme)}
-  ${({ color, theme }) => colorStyles[color](theme)}
-  ${({ shape }) => shapeStyles(shape)}
+    ${({ color, theme, borderColor }) => colorStyles[color](theme, borderColor ?? 'primary')}
+    ${({ shape }) => shapeStyles(shape)}
 `;
 
 const S = {

--- a/src/components/_common/atoms/Button/style.ts
+++ b/src/components/_common/atoms/Button/style.ts
@@ -10,7 +10,7 @@ export interface ButtonStyleProps {
   size: ButtonSize;
   color: ButtonColor;
   shape?: ButtonShape;
-  borderColor?: ButtonBorderColor; // 선택적 속성으로 변경
+  borderColor?: ButtonBorderColor;
 }
 
 const commonStyles = (theme: Theme) => css`
@@ -83,8 +83,8 @@ const shapeStyles = (shape: ButtonShape = 'default') => css`
 const Button = styled.button<ButtonStyleProps>`
   ${({ theme }) => commonStyles(theme)}
   ${({ size, theme }) => sizeStyles[size](theme)}
-    ${({ color, theme, borderColor }) => colorStyles[color](theme, borderColor ?? 'primary')}
-    ${({ shape }) => shapeStyles(shape)}
+  ${({ color, theme, borderColor }) => colorStyles[color](theme, borderColor ?? 'primary')}
+  ${({ shape }) => shapeStyles(shape)}
 `;
 
 const S = {

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -3,7 +3,6 @@ import { generatePath } from 'react-router-dom';
 export const PATH = {
   ROOT: '/',
   STUDY: {
-    LIST: '/',
     CREATE: '/study/create',
     EDIT: '/study/:studyId/edit',
     PARTICIPATION: '/study/:studyId/participation',
@@ -26,7 +25,6 @@ export const PATH = {
 export const ROUTES = {
   ROOT: () => generatePath(PATH.ROOT),
   STUDY: {
-    LIST: () => generatePath(PATH.STUDY.LIST),
     CREATE: () => generatePath(PATH.STUDY.CREATE),
     EDIT: ({ studyId }: { studyId: number }) => generatePath(PATH.STUDY.EDIT, { studyId }),
     PARTICIPATION: ({ studyId }: { studyId: number }) => generatePath(PATH.STUDY.PARTICIPATION, { studyId }),

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -3,7 +3,7 @@ import { generatePath } from 'react-router-dom';
 export const PATH = {
   ROOT: '/',
   STUDY: {
-    LIST: '/study',
+    LIST: '/',
     CREATE: '/study/create',
     EDIT: '/study/:studyId/edit',
     PARTICIPATION: '/study/:studyId/participation',

--- a/src/hooks/study/useLeaveStudy.ts
+++ b/src/hooks/study/useLeaveStudy.ts
@@ -5,11 +5,13 @@ import QUERY_KEYS from '@constants/queryKeys';
 export default function useLeaveStudy({ navigate }: { navigate?: () => void }) {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  const leaveStudyMutate = useMutation({
     mutationFn: studyApi.leave,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.STUDY_LIST] });
       navigate?.();
     },
   });
+
+  return { leaveStudyMutate };
 }

--- a/src/hooks/study/useLeaveStudy.ts
+++ b/src/hooks/study/useLeaveStudy.ts
@@ -1,23 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 import studyApi from '@api/domain/study';
 import QUERY_KEYS from '@constants/queryKeys';
-import { ROUTES } from '@constants/path';
 
 export default function useLeaveStudy() {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
 
-  const leaveStudyMutate = useMutation({
+  return useMutation({
     mutationFn: studyApi.leave,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.STUDY_LIST] });
-      navigate(ROUTES.STUDY.LIST());
-    },
-    onError: (error) => {
-      console.error('스터디 나가기 실패:', error);
     },
   });
-
-  return leaveStudyMutate;
 }

--- a/src/hooks/study/useLeaveStudy.ts
+++ b/src/hooks/study/useLeaveStudy.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import studyApi from '@api/domain/study';
+import QUERY_KEYS from '@constants/queryKeys';
+import { ROUTES } from '@constants/path';
+
+export default function useLeaveStudy() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const leaveStudyMutate = useMutation({
+    mutationFn: studyApi.leave,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.STUDY_LIST] });
+      navigate(ROUTES.STUDY.LIST());
+    },
+    onError: (error) => {
+      console.error('스터디 나가기 실패:', error);
+    },
+  });
+
+  return leaveStudyMutate;
+}

--- a/src/hooks/study/useLeaveStudy.ts
+++ b/src/hooks/study/useLeaveStudy.ts
@@ -2,13 +2,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import studyApi from '@api/domain/study';
 import QUERY_KEYS from '@constants/queryKeys';
 
-export default function useLeaveStudy() {
+export default function useLeaveStudy({ navigate }: { navigate?: () => void }) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: studyApi.leave,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.STUDY_LIST] });
+      navigate?.();
     },
   });
 }

--- a/src/mocks/data/study/getStudyListData.ts
+++ b/src/mocks/data/study/getStudyListData.ts
@@ -6,7 +6,7 @@ export const getStudyListResponse = {
     studies: [
       {
         id: 7,
-        joinable: false,
+        joinable: true,
         name: '매일 열심히하는 스터디',
         status: 'PUBLIC',
         languages: [

--- a/src/mocks/data/study/getStudyListData.ts
+++ b/src/mocks/data/study/getStudyListData.ts
@@ -6,7 +6,7 @@ export const getStudyListResponse = {
     studies: [
       {
         id: 7,
-        joinable: true,
+        joinable: false,
         name: '매일 열심히하는 스터디',
         status: 'PUBLIC',
         languages: [

--- a/src/mocks/data/study/leaveStudyData.ts
+++ b/src/mocks/data/study/leaveStudyData.ts
@@ -1,0 +1,9 @@
+export const leaveStudyResponse = {
+  code: 1200,
+  message: '스터디 퇴장에 성공했습니다.',
+};
+
+export const leaveStudyErrorResponse = {
+  code: 4200,
+  message: '스터디 퇴장에 실패했습니다.',
+};

--- a/src/mocks/data/user.ts
+++ b/src/mocks/data/user.ts
@@ -2,7 +2,7 @@ export const getUserInfoResponse = {
   code: 1000,
   message: '사용자 정보를 조회했습니다.',
   result: {
-    id: 1,
+    id: 2,
     nickname: '코코무',
     profileImageUrl: 'https://cdn.cocomu.co.kr/images/default/Logo.png',
   },

--- a/src/mocks/data/user.ts
+++ b/src/mocks/data/user.ts
@@ -2,7 +2,7 @@ export const getUserInfoResponse = {
   code: 1000,
   message: '사용자 정보를 조회했습니다.',
   result: {
-    id: 2,
+    id: 1,
     nickname: '코코무',
     profileImageUrl: 'https://cdn.cocomu.co.kr/images/default/Logo.png',
   },

--- a/src/mocks/handlers/study.ts
+++ b/src/mocks/handlers/study.ts
@@ -18,6 +18,7 @@ import {
   joinPublicStudyResponse,
 } from '@mocks/data/study/joinStudyData';
 import { getStudyDetailErrorResponse, getStudyDetailResponse } from '@mocks/data/study/getStudyDetailData';
+import { leaveStudyErrorResponse, leaveStudyResponse } from '@mocks/data/study/leaveStudyData';
 
 export const studyHandlers = [
   http.get(

--- a/src/mocks/handlers/study.ts
+++ b/src/mocks/handlers/study.ts
@@ -148,4 +148,18 @@ export const studyHandlers = [
       status: HTTP_STATUS_CODE.SUCCESS,
     });
   }),
+
+  http.post(`${BASE_URL}${END_POINTS_V1.STUDY.LEAVE(':studyId')}`, async ({ params }) => {
+    const { studyId } = params;
+
+    if (!studyId) {
+      return new HttpResponse(JSON.stringify(leaveStudyErrorResponse), {
+        status: HTTP_STATUS_CODE.BAD_REQUEST,
+      });
+    }
+
+    return new HttpResponse(JSON.stringify(leaveStudyResponse), {
+      status: HTTP_STATUS_CODE.SUCCESS,
+    });
+  }),
 ];

--- a/src/pages/Study/StudyInfo/index.tsx
+++ b/src/pages/Study/StudyInfo/index.tsx
@@ -20,6 +20,7 @@ export default function StudyInfo() {
       totalUserCount={data.totalUserCount}
       createdAt={data.createdAt}
       leader={data.leader}
+      isStudy
     />
   );
 }

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -42,6 +42,7 @@ export interface TestCaseProps {
 export interface LeaveProps {
   studyId?: string;
   name?: string;
+  navigate?: () => void;
   onClose?: () => void;
 }
 

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -3,6 +3,7 @@ import Login from '@components/Modal/Login';
 import PasswordInput from '@components/Modal/PasswordInput';
 import Waiting from '@components/Modal/Waiting';
 import TestCaseModal from '@components/Modal/TestCase';
+import LeaveModal from '@components/Modal/Leave';
 import { TestCaseData } from './space';
 
 export interface WaitingProps {
@@ -38,6 +39,12 @@ export interface TestCaseProps {
   onClose?: () => void;
 }
 
+export interface LeaveProps {
+  studyId?: string;
+  name?: string;
+  onClose?: () => void;
+}
+
 interface ModalConfig<T> {
   Component: React.FC<T>;
   disableOutsideClick?: boolean;
@@ -49,10 +56,12 @@ export const MODAL_COMPONENTS: {
   passwordInput: ModalConfig<PasswordInputProps>;
   testCase: ModalConfig<TestCaseProps>;
   login: ModalConfig<LoginProps>;
+  leave: ModalConfig<LeaveProps>;
 } = {
   waiting: { Component: Waiting, disableOutsideClick: true },
   confirm: { Component: ConfirmModal },
   passwordInput: { Component: PasswordInput },
   testCase: { Component: TestCaseModal },
   login: { Component: Login },
+  leave: { Component: LeaveModal },
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #113 

<br/>

## 🔎 작업 내용

- 스터디 나가기 구현
- Leave 모달 컴포넌트 추가 및 적용
- path StudyList 페이지 경로 수정
- Button 컴포넌트 borderColor 조건 추가

<br/>

## 이미지 첨부(선택)

mocks/data/user.ts 의 getUserInfoResponse/result/id 를 studyId 랑 같지 않게 설정하면 스터디장이 아닌 스터디원으로 스터디 정보 조회 가능하고, 스터디 나가기 버튼 활성화 됩니다.
![image](https://github.com/user-attachments/assets/e7432d5b-65da-48ba-999b-1839329e1c3b)

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
