### PR TITLE
COC-119 스터디 삭제 구현

### DIFF
--- a/src/api/domain/study.ts
+++ b/src/api/domain/study.ts
@@ -68,13 +68,11 @@ const studyApi = {
   },
 
   leave: async (studyId: string) => {
-    const { data } = await axiosInstance.post(END_POINTS_V1.STUDY.LEAVE(studyId));
-    return data;
+    await axiosInstance.post(END_POINTS_V1.STUDY.LEAVE(studyId));
   },
 
   delete: async (studyId: string) => {
-    const { data } = await axiosInstance.delete(END_POINTS_V1.STUDY.DELETE(studyId));
-    return data;
+    await axiosInstance.delete(END_POINTS_V1.STUDY.DELETE(studyId));
   },
 };
 

--- a/src/api/domain/study.ts
+++ b/src/api/domain/study.ts
@@ -71,6 +71,11 @@ const studyApi = {
     const { data } = await axiosInstance.post(END_POINTS_V1.STUDY.LEAVE(studyId));
     return data;
   },
+
+  delete: async (studyId: string) => {
+    const { data } = await axiosInstance.delete(END_POINTS_V1.STUDY.DELETE(studyId));
+    return data;
+  },
 };
 
 export default studyApi;

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -3,7 +3,6 @@ import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axio
 import { HTTPError } from '@api/HTTPError';
 import { axiosInstance } from '@api/axiosInstance';
 
-import { PATH } from '@constants/path';
 import { ACCESS_TOKEN_KEY, ERROR_CODE, HTTP_STATUS_CODE } from '@constants/api';
 import authApi from './domain/auth';
 
@@ -18,8 +17,7 @@ export const checkAndSetToken = (config: InternalAxiosRequestConfig) => {
   const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
 
   if (!accessToken) {
-    window.location.href = PATH.ROOT;
-    throw new Error('토큰이 유효하지 않습니다');
+    throw new Error('로그인을 해주세요.');
   }
 
   // eslint-disable-next-line

--- a/src/components/Modal/Delete/index.tsx
+++ b/src/components/Modal/Delete/index.tsx
@@ -1,0 +1,37 @@
+import Button from '@components/_common/atoms/Button';
+import useDeleteStudy from '@hooks/study/useDeleteStudy';
+import { DeleteProps } from '@customTypes/modal';
+import S from './style';
+
+export default function DeleteModal({ studyId, name, onClose, navigate }: DeleteProps) {
+  const { deleteStudyMutate } = useDeleteStudy({ navigate });
+
+  const handleConfirm = () => {
+    deleteStudyMutate.mutate(studyId);
+    onClose();
+  };
+
+  return (
+    <S.Container>
+      <S.Description>{name}</S.Description>
+      <S.Instruction>스터디를 삭제하시겠습니까?</S.Instruction>
+      <S.ButtonWrapper>
+        <Button
+          color='triadic'
+          size='md'
+          onClick={handleConfirm}
+        >
+          확인
+        </Button>
+        <Button
+          color='white'
+          size='md'
+          borderColor='triadic'
+          onClick={onClose}
+        >
+          취소
+        </Button>
+      </S.ButtonWrapper>
+    </S.Container>
+  );
+}

--- a/src/components/Modal/Delete/style.ts
+++ b/src/components/Modal/Delete/style.ts
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4rem;
+
+  padding: 6.6rem 15rem 6.2rem 15rem;
+`;
+
+const Description = styled.p`
+  ${({ theme }) => theme.font.heading[300]};
+  color: ${({ theme }) => theme.color.gray[900]};
+`;
+
+const Instruction = styled.p`
+  ${({ theme }) => theme.font.heading[500]};
+  color: ${({ theme }) => theme.color.gray[950]};
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-self: center;
+  gap: 1.3rem;
+
+  height: 4.2rem;
+  margin-top: 1rem;
+`;
+
+const S = { Container, Description, Instruction, ButtonWrapper };
+export default S;

--- a/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
+++ b/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
@@ -34,7 +34,7 @@ export default function DescriptionHeader({ isLeader, isStudy, leader, studyId, 
       navigate(ROUTES.STUDY.EDIT({ studyId }));
     } else if (selectedItem === STUDY_EDIT_DROPDOWN_LABELS[1].label) {
       open('delete', {
-        studyId,
+        studyId: String(studyId),
         name,
         navigate: () => navigate(ROUTES.ROOT()),
       });
@@ -44,7 +44,7 @@ export default function DescriptionHeader({ isLeader, isStudy, leader, studyId, 
 
   const handleLeaveClick = () => {
     open('leave', {
-      studyId,
+      studyId: String(studyId),
       name,
       navigate: () => navigate(ROUTES.ROOT()),
     });

--- a/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
+++ b/src/components/Study/StudyDescription/DescriptionHeader/index.tsx
@@ -19,9 +19,10 @@ interface DescriptionHeaderProps {
   isStudy: boolean;
   leader: UserData;
   studyId: number;
+  name: string;
 }
 
-export default function DescriptionHeader({ isLeader, isStudy, leader, studyId }: DescriptionHeaderProps) {
+export default function DescriptionHeader({ isLeader, isStudy, leader, studyId, name }: DescriptionHeaderProps) {
   const navigate = useNavigate();
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const { open } = useModalStore();
@@ -32,15 +33,19 @@ export default function DescriptionHeader({ isLeader, isStudy, leader, studyId }
     if (selectedItem === STUDY_EDIT_DROPDOWN_LABELS[0].label) {
       navigate(ROUTES.STUDY.EDIT({ studyId }));
     } else if (selectedItem === STUDY_EDIT_DROPDOWN_LABELS[1].label) {
-      // TODO: 스터디 삭제 API 호출
+      open('delete', {
+        studyId,
+        name,
+        navigate: () => navigate(ROUTES.ROOT()),
+      });
     }
     setDropdownOpen(false);
   };
 
   const handleLeaveClick = () => {
     open('leave', {
-      studyId: String(studyId),
-      name: leader.nickname,
+      studyId,
+      name,
       navigate: () => navigate(ROUTES.ROOT()),
     });
   };

--- a/src/components/Study/StudyDescription/index.tsx
+++ b/src/components/Study/StudyDescription/index.tsx
@@ -33,6 +33,7 @@ export default function StudyDescription({
         isStudy={isStudy}
         leader={leader}
         studyId={id}
+        name={name}
       />
 
       <S.Body>

--- a/src/hooks/space/useGetSpaceList.ts
+++ b/src/hooks/space/useGetSpaceList.ts
@@ -17,6 +17,5 @@ export default function useGetSpaceList({ studyId, params }: UseGetSpaceListProp
       if (!lastPage?.codingSpaces.length) return null;
       return lastPage.lastId ?? null;
     },
-    staleTime: 1000 * 60 * 3,
   });
 }

--- a/src/hooks/study/useDeleteStudy.ts
+++ b/src/hooks/study/useDeleteStudy.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import studyApi from '@api/domain/study';
+import QUERY_KEYS from '@constants/queryKeys';
+
+export default function useDeleteStudy({ navigate }: { navigate?: () => void }) {
+  const queryClient = useQueryClient();
+
+  const deleteStudyMutate = useMutation({
+    mutationFn: studyApi.delete,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.STUDY_LIST] });
+      navigate?.();
+    },
+  });
+
+  return { deleteStudyMutate };
+}

--- a/src/hooks/study/useGetStudyList.ts
+++ b/src/hooks/study/useGetStudyList.ts
@@ -8,6 +8,5 @@ export default function useGetStudyList(params: GetListData) {
   return useQuery({
     queryKey: [QUERY_KEYS.STUDY_LIST, params],
     queryFn: () => studyApi.getList(params),
-    staleTime: 1000 * 60 * 1,
   });
 }

--- a/src/mocks/data/study/deleteStudyData.ts
+++ b/src/mocks/data/study/deleteStudyData.ts
@@ -1,0 +1,9 @@
+export const deleteStudyResponse = {
+  code: 1200,
+  message: '스터디 삭제에 성공했습니다.',
+};
+
+export const deleteStudyErrorResponse = {
+  code: 4200,
+  message: '스터디 삭제에 실패했습니다.',
+};

--- a/src/mocks/handlers/study.ts
+++ b/src/mocks/handlers/study.ts
@@ -19,6 +19,7 @@ import {
 } from '@mocks/data/study/joinStudyData';
 import { getStudyDetailErrorResponse, getStudyDetailResponse } from '@mocks/data/study/getStudyDetailData';
 import { leaveStudyErrorResponse, leaveStudyResponse } from '@mocks/data/study/leaveStudyData';
+import { deleteStudyErrorResponse, deleteStudyResponse } from '@mocks/data/study/deleteStudyData';
 
 export const studyHandlers = [
   http.get(
@@ -160,6 +161,20 @@ export const studyHandlers = [
     }
 
     return new HttpResponse(JSON.stringify(leaveStudyResponse), {
+      status: HTTP_STATUS_CODE.SUCCESS,
+    });
+  }),
+
+  http.delete(`${BASE_URL}${END_POINTS_V1.STUDY.DELETE(':studyId')}`, async ({ params }) => {
+    const { studyId } = params;
+
+    if (!studyId) {
+      return new HttpResponse(JSON.stringify(deleteStudyErrorResponse), {
+        status: HTTP_STATUS_CODE.BAD_REQUEST,
+      });
+    }
+
+    return new HttpResponse(JSON.stringify(deleteStudyResponse), {
       status: HTTP_STATUS_CODE.SUCCESS,
     });
   }),

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -4,6 +4,7 @@ import PasswordInput from '@components/Modal/PasswordInput';
 import Waiting from '@components/Modal/Waiting';
 import TestCase from '@components/Modal/TestCase';
 import LeaveModal from '@components/Modal/Leave';
+import DeleteModal from '@components/Modal/Delete';
 import { TestCaseData } from './space';
 
 export interface WaitingProps {
@@ -46,6 +47,13 @@ export interface LeaveProps {
   onClose?: () => void;
 }
 
+export interface DeleteProps {
+  studyId?: string;
+  name?: string;
+  navigate?: () => void;
+  onClose?: () => void;
+}
+
 interface ModalConfig<T> {
   Component: React.FC<T>;
   disableOutsideClick?: boolean;
@@ -58,6 +66,7 @@ export const MODAL_COMPONENTS: {
   testCase: ModalConfig<TestCaseProps>;
   login: ModalConfig<LoginProps>;
   leave: ModalConfig<LeaveProps>;
+  delete: ModalConfig<DeleteProps>;
 } = {
   waiting: { Component: Waiting, disableOutsideClick: true },
   confirm: { Component: ConfirmModal },
@@ -65,4 +74,5 @@ export const MODAL_COMPONENTS: {
   testCase: { Component: TestCase },
   login: { Component: Login },
   leave: { Component: LeaveModal },
+  delete: { Component: DeleteModal },
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #123 

<br/>

## 🔎 작업 내용

- 스터디 삭제 api 구현 및 적용,
- Delete 모달 컴포넌트 추가 및 적용
- delete, leave 모달 open 함수 받아오는 형식 수정

<br/>

## 이미지 첨부(선택)

mocks/data/user.ts 의 getUserInfoResponse/result/id 를 studyId 랑 같게 설정하면 스터디원이 아닌 스터디장으로 스터디 정보 조회 가능하고, 스터디 삭제가 들어있는 드롭다운 버튼이 활성화 됩니다.
![image](https://github.com/user-attachments/assets/da5d699e-2622-4d3a-8de3-f69dce34449c)

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
