### PR TITLE
Fix/#191 Footer 배너 수정 요소 반영

### DIFF
--- a/src/components/_common/atoms/MoveTopButton/index.tsx
+++ b/src/components/_common/atoms/MoveTopButton/index.tsx
@@ -1,14 +1,8 @@
 import { BsFillCaretUpFill } from 'react-icons/bs';
 import S from './style';
+import { scrollToTop } from '../../../../utils/scrollToTop';
 
 export default function MoveTopButton() {
-  const scrollToTop = (): void => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
-  };
-
   return (
     <S.ScrollButton onClick={scrollToTop}>
       <S.IconContainer>

--- a/src/hooks/utils/useNavigateClick.ts
+++ b/src/hooks/utils/useNavigateClick.ts
@@ -1,0 +1,15 @@
+import { useNavigate } from 'react-router-dom';
+
+export const useNavigateClick = (path: number | string) => {
+  const navigate = useNavigate();
+
+  return () => {
+    if (typeof path === 'number') {
+      navigate(path);
+    } else if (path === '/') {
+      window.location.href = '/';
+    } else {
+      navigate(`${path}`);
+    }
+  };
+};

--- a/src/pages/MainLayout/Footer/index.tsx
+++ b/src/pages/MainLayout/Footer/index.tsx
@@ -28,10 +28,6 @@ export default function Footer() {
             name='Email'
             description='cocomuteam@gmail.com'
           />
-          <FooterLabel
-            name='TEL'
-            description='010-XXXX-XXXX'
-          />
           <FooterLabel name='© 2025 deepdive-cocomu. MIT License.' />
         </S.LabelContainer>
       </S.InfoSection>

--- a/src/pages/MainLayout/Footer/index.tsx
+++ b/src/pages/MainLayout/Footer/index.tsx
@@ -1,12 +1,17 @@
 import FooterLabel from '@pages/MainLayout/Footer/FooterLabel';
 import { LOGO_IMAGE } from '@constants/common/image';
 import { MENU_LIST } from '@constants/common/option';
-import { useNavigate } from 'react-router-dom';
-import { scrollToTop } from '../../../utils/scrollToTop';
+import { useNavigateClick } from '@hooks/utils/useNavigateClick';
+import { scrollToTop } from '@utils/scrollToTop';
 import S from './style';
 
 export default function Footer() {
-  const navigate = useNavigate();
+  const navigateHome = useNavigateClick('/');
+
+  const logoClick = () => {
+    navigateHome();
+    scrollToTop();
+  };
 
   const handleMenuClick = (index: number) => {
     if (index === 0) {
@@ -18,11 +23,6 @@ export default function Footer() {
     } else {
       /* console.log('문의 게시판 개발 중...'); */
     }
-  };
-
-  const logoClick = () => {
-    navigate('/');
-    scrollToTop();
   };
 
   return (

--- a/src/pages/MainLayout/Footer/index.tsx
+++ b/src/pages/MainLayout/Footer/index.tsx
@@ -22,6 +22,7 @@ export default function Footer() {
 
   const logoClick = () => {
     navigate('/');
+    scrollToTop();
   };
 
   return (
@@ -30,10 +31,7 @@ export default function Footer() {
         <S.LogoImg
           src={LOGO_IMAGE}
           alt='Logo'
-          onClick={() => {
-            logoClick();
-            scrollToTop();
-          }}
+          onClick={logoClick}
         />
         <S.LabelContainer>
           <FooterLabel

--- a/src/pages/MainLayout/Footer/index.tsx
+++ b/src/pages/MainLayout/Footer/index.tsx
@@ -26,7 +26,7 @@ export default function Footer() {
         <S.LabelContainer>
           <FooterLabel
             name='Email'
-            description='deepdive@mail.com'
+            description='cocomuteam@gmail.com'
           />
           <FooterLabel
             name='TEL'

--- a/src/pages/MainLayout/Footer/index.tsx
+++ b/src/pages/MainLayout/Footer/index.tsx
@@ -1,9 +1,13 @@
 import FooterLabel from '@pages/MainLayout/Footer/FooterLabel';
 import { LOGO_IMAGE } from '@constants/common/image';
 import { MENU_LIST } from '@constants/common/option';
+import { useNavigate } from 'react-router-dom';
+import { scrollToTop } from '../../../utils/scrollToTop';
 import S from './style';
 
 export default function Footer() {
+  const navigate = useNavigate();
+
   const handleMenuClick = (index: number) => {
     if (index === 0) {
       /* console.log('이용약관 작성 중...'); */
@@ -16,12 +20,20 @@ export default function Footer() {
     }
   };
 
+  const logoClick = () => {
+    navigate('/');
+  };
+
   return (
     <S.Container>
       <S.InfoSection>
         <S.LogoImg
           src={LOGO_IMAGE}
           alt='Logo'
+          onClick={() => {
+            logoClick();
+            scrollToTop();
+          }}
         />
         <S.LabelContainer>
           <FooterLabel

--- a/src/pages/MainLayout/Footer/style.ts
+++ b/src/pages/MainLayout/Footer/style.ts
@@ -33,7 +33,7 @@ const LabelContainer = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   align-items: start;
-  gap: 1rem;
+  gap: 1.5rem;
 `;
 
 const MenuSection = styled.div`

--- a/src/pages/MainLayout/Footer/style.ts
+++ b/src/pages/MainLayout/Footer/style.ts
@@ -26,6 +26,7 @@ const LogoImg = styled.img`
   width: 12rem;
   object-fit: contain;
   align-items: center;
+  cursor: pointer;
 `;
 
 const LabelContainer = styled.div`

--- a/src/pages/MainLayout/Footer/style.ts
+++ b/src/pages/MainLayout/Footer/style.ts
@@ -31,9 +31,10 @@ const LogoImg = styled.img`
 const LabelContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: start;
-  gap: 1.5rem;
+
+  gap: 1rem;
 `;
 
 const MenuSection = styled.div`

--- a/src/pages/MainLayout/Footer/style.ts
+++ b/src/pages/MainLayout/Footer/style.ts
@@ -9,6 +9,7 @@ const Container = styled.div`
   background-color: ${({ theme }) => theme.color.gray[300]};
 
   padding: 5rem 0;
+  gap: 20rem;
 `;
 
 const InfoSection = styled.div`
@@ -24,6 +25,7 @@ const InfoSection = styled.div`
 const LogoImg = styled.img`
   width: 12rem;
   object-fit: contain;
+  align-items: center;
 `;
 
 const LabelContainer = styled.div`

--- a/src/pages/Study/StudyList/StudyFilterTab/index.tsx
+++ b/src/pages/Study/StudyList/StudyFilterTab/index.tsx
@@ -10,12 +10,10 @@ import S from './style';
 
 interface FilterTabProps {
   filters: studyFilters;
-  keyword: string;
   setFilters: React.Dispatch<React.SetStateAction<studyFilters>>;
-  setKeyword: (keyword: string) => void;
 }
 
-export default function StudyFilterTab({ filters, keyword, setFilters, setKeyword }: FilterTabProps) {
+export default function StudyFilterTab({ filters, setFilters }: FilterTabProps) {
   const { data, isLoading } = useGetFilterOptions();
 
   if (isLoading) return null;
@@ -61,9 +59,9 @@ export default function StudyFilterTab({ filters, keyword, setFilters, setKeywor
       </S.DropdownWrapper>
       <SearchInput
         placeholder='제목을 검색해주세요'
-        value={keyword}
-        onChange={setKeyword}
-        onSearch={() => changeStudyFilters('keyword', keyword)}
+        value={filters.keyword}
+        onChange={(value) => changeStudyFilters('keyword', value)}
+        onSearch={() => changeStudyFilters('keyword', filters.keyword)}
       />
     </S.FilterTabContainer>
   );

--- a/src/pages/Study/StudyList/StudyFilterTab/index.tsx
+++ b/src/pages/Study/StudyList/StudyFilterTab/index.tsx
@@ -1,24 +1,17 @@
 import { ACCESS_STATUS } from '@constants/common/option';
+import { studyFilters } from '@customTypes/study';
 
 import SelectDropdown from '@components/_common/molecules/SelectDropdown';
 import ToggleButton from '@components/_common/atoms/ToggleButton';
 import SearchInput from '@components/_common/atoms/SearchInput';
 
 import useGetFilterOptions from '@hooks/study/useGetFilterOptions';
-
 import S from './style';
 
-interface Filters {
-  status: number[];
-  languages: number[];
-  workbooks: number[];
-  joinable: boolean;
-}
-
 interface FilterTabProps {
-  filters: Filters;
+  filters: studyFilters;
   keyword: string;
-  setFilters: React.Dispatch<React.SetStateAction<Filters>>;
+  setFilters: React.Dispatch<React.SetStateAction<studyFilters>>;
   setKeyword: (keyword: string) => void;
 }
 
@@ -34,27 +27,47 @@ export default function StudyFilterTab({ filters, keyword, setFilters, setKeywor
           items={[...ACCESS_STATUS]}
           description='전체'
           values={filters.status}
-          onSelect={(values) => setFilters((prev) => ({ ...prev, status: values }))}
+          onSelect={(values) =>
+            setFilters((prev) => ({
+              ...prev,
+              status: values,
+            }))
+          }
         />
         <SelectDropdown
           items={data.languages}
           description='사용 언어'
           values={filters.languages}
-          onSelect={(values) => setFilters((prev) => ({ ...prev, languages: values }))}
+          onSelect={(values) =>
+            setFilters((prev) => ({
+              ...prev,
+              languages: values,
+            }))
+          }
           isMultiSelect
         />
         <SelectDropdown
           items={data.workbooks}
           description='사용 플랫폼'
           values={filters.workbooks}
-          onSelect={(values) => setFilters((prev) => ({ ...prev, workbooks: values }))}
+          onSelect={(values) =>
+            setFilters((prev) => ({
+              ...prev,
+              workbooks: values,
+            }))
+          }
           isMultiSelect
         />
         <ToggleButton
           size='md'
           shape='round'
           isActive={filters.joinable}
-          onToggle={(value) => setFilters((prev) => ({ ...prev, joinable: value }))}
+          onToggle={(value) =>
+            setFilters((prev) => ({
+              ...prev,
+              joinable: value,
+            }))
+          }
         >
           참여 가능한 스터디 보기
         </ToggleButton>
@@ -63,7 +76,12 @@ export default function StudyFilterTab({ filters, keyword, setFilters, setKeywor
         placeholder='제목을 검색해주세요'
         value={keyword}
         onChange={setKeyword}
-        onSearch={() => setFilters((prev) => ({ ...prev, keyword }))}
+        onSearch={() =>
+          setFilters((prev) => ({
+            ...prev,
+            keyword,
+          }))
+        }
       />
     </S.FilterTabContainer>
   );

--- a/src/pages/Study/StudyList/StudyFilterTab/index.tsx
+++ b/src/pages/Study/StudyList/StudyFilterTab/index.tsx
@@ -20,6 +20,13 @@ export default function StudyFilterTab({ filters, keyword, setFilters, setKeywor
 
   if (isLoading) return null;
 
+  const changeStudyFilters = <K extends keyof studyFilters>(key: K, value: studyFilters[K]) => {
+    setFilters((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+
   return (
     <S.FilterTabContainer>
       <S.DropdownWrapper>
@@ -27,47 +34,27 @@ export default function StudyFilterTab({ filters, keyword, setFilters, setKeywor
           items={[...ACCESS_STATUS]}
           description='전체'
           values={filters.status}
-          onSelect={(values) =>
-            setFilters((prev) => ({
-              ...prev,
-              status: values,
-            }))
-          }
+          onSelect={(values) => changeStudyFilters('status', values)}
         />
         <SelectDropdown
           items={data.languages}
           description='사용 언어'
           values={filters.languages}
-          onSelect={(values) =>
-            setFilters((prev) => ({
-              ...prev,
-              languages: values,
-            }))
-          }
+          onSelect={(values) => changeStudyFilters('languages', values)}
           isMultiSelect
         />
         <SelectDropdown
           items={data.workbooks}
           description='사용 플랫폼'
           values={filters.workbooks}
-          onSelect={(values) =>
-            setFilters((prev) => ({
-              ...prev,
-              workbooks: values,
-            }))
-          }
+          onSelect={(values) => changeStudyFilters('workbooks', values)}
           isMultiSelect
         />
         <ToggleButton
           size='md'
           shape='round'
           isActive={filters.joinable}
-          onToggle={(value) =>
-            setFilters((prev) => ({
-              ...prev,
-              joinable: value,
-            }))
-          }
+          onToggle={(value) => changeStudyFilters('joinable', value)}
         >
           참여 가능한 스터디 보기
         </ToggleButton>
@@ -76,12 +63,7 @@ export default function StudyFilterTab({ filters, keyword, setFilters, setKeywor
         placeholder='제목을 검색해주세요'
         value={keyword}
         onChange={setKeyword}
-        onSearch={() =>
-          setFilters((prev) => ({
-            ...prev,
-            keyword,
-          }))
-        }
+        onSearch={() => changeStudyFilters('keyword', keyword)}
       />
     </S.FilterTabContainer>
   );

--- a/src/pages/Study/StudyList/index.tsx
+++ b/src/pages/Study/StudyList/index.tsx
@@ -40,9 +40,7 @@ export default function StudyList() {
       <Slider images={BANNER_IMAGES} />
       <StudyFilterTab
         filters={filters}
-        keyword={keyword}
         setFilters={setFilters}
-        setKeyword={setKeyword}
       />
       {isLoading ? (
         <Loading />
@@ -62,7 +60,12 @@ export default function StudyList() {
               <PageButton
                 totalPage={Math.ceil(data.totalStudyCount / STUDY_PAGE_SIZE)}
                 currentPage={filters.page}
-                setPage={(page) => setFilters((prev) => ({ ...prev, page }))}
+                setPage={(page) =>
+                  setFilters((prev) => ({
+                    ...prev,
+                    page,
+                  }))
+                }
               />
             </S.Footer>
           )}

--- a/src/stories/_common/atoms/Button.stories.ts
+++ b/src/stories/_common/atoms/Button.stories.ts
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import Button from '@components/_common/atoms/Button';
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: 'Atoms/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+      description: '버튼 내용',
+    },
+  },
+  args: { onClick: fn() },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    label: 'Button',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'large',
+    label: 'Button',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'small',
+    label: 'Button',
+  },
+};

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -8,6 +8,7 @@ export interface studyFilters {
   languages: number[];
   workbooks: number[];
   joinable: boolean;
+  keyword: string;
 }
 
 export interface StudyData {

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -3,6 +3,13 @@ import { UserData } from './user';
 
 export type StudyStatusData = 'PUBLIC' | 'PRIVATE';
 
+export interface studyFilters {
+  status: number[];
+  languages: number[];
+  workbooks: number[];
+  joinable: boolean;
+}
+
 export interface StudyData {
   id: number;
   joinable: boolean;

--- a/src/utils/scrollToTop.ts
+++ b/src/utils/scrollToTop.ts
@@ -1,0 +1,6 @@
+export const scrollToTop = (): void => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth',
+  });
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #191 

<br/>

## 🔎 작업 내용

- footer 하위 컴포넌트 재배치
- 전화번호 레이블 제거
- 로고 이미지에 클릭 이벤트 추가
- scrollToTop 함수 util 함수 전환
   - top 버튼과 하단 로고 이미지에서 사용 -> util 디렉토리로 이동
- useNavigateClick 커스텀 훅 추가 
 
<br/>

## 이미지 첨부(선택)
![image](https://github.com/user-attachments/assets/eb1a1bfe-faab-4bcc-893b-850ad54d4595)

<br/>

## 💬 리뷰 요구사항(선택)

> 루트 디렉토리로 가는 함수도 구현하였고 scrollToTop 유틸 함수도 호출하여 사용하므로 하단 로고 이미지 클릭 함수에 두 개의 호출이 들어가게 되는데 이 부분에서 제가 생각했을 때 메인 페이지만 하단 바가 있다면 navigate() 함수를 사용하지 않아도 될 것 같은데 만약 다른 곳에도 들어가게 된다면 루트 경로로 navigate하는 함수는 필요하다고 생각합니다. 

> 또한 하단 바를 UX 적인 측면으로 생각하게 되면 코딩 스페이스를 제외한 모든 곳에 들어가야 된다고 생각합니다. 혹시 이러한 이슈에 대해서 팀원 분들의 의견을 구해봐도 괜찮을까요? 